### PR TITLE
fix: verify socks5 listener via tcpSocket probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Probe the SOCKS5 port via `tcpSocket` for readiness and add a liveness probe.
+
+### Removed
+
+- Remove the always-ok `/healthz` endpoint.
+
 ## [0.3.0] - 2026-07-07
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,6 @@ to quickly create a Cobra application.`,
 	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
 
-		http.HandleFunc("/healthz", health)
 		http.Handle("/metrics", promhttp.Handler())
 
 		go func() {
@@ -106,8 +105,4 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
-}
-
-func health(w http.ResponseWriter, req *http.Request) {
-	_, _ = fmt.Fprintf(w, "ok\n")
 }

--- a/helm/proxysocks/templates/deployment.yaml
+++ b/helm/proxysocks/templates/deployment.yaml
@@ -27,9 +27,13 @@ spec:
             - name: socks5
               containerPort: {{ .Values.service.port }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8090
+            tcpSocket:
+              port: socks5
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: socks5
             initialDelaySeconds: 5
             periodSeconds: 10
           {{- with .Values.resources }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37110

The readiness probe hit `/healthz`, which always returned ok regardless of whether the SOCKS5 listener was alive, so it proved nothing about the proxy.

### Changes

- Switch the readiness probe to `tcpSocket` on the named `socks5` port, which verifies the port clients actually use.
- Add a liveness probe with the same check.
- Remove the always-ok `/healthz` handler; the HTTP server on `:8090` now serves `/metrics` only.

A dial check inside `/healthz` was considered and discarded: it verifies exactly the same thing (a bare TCP accept) while coupling probe health to the metrics server. Note that both approaches cause go-socks5 to log a `server: EOF` error line per probe; this noise already exists via the NLB health checks and will be addressed with the logging rework (point 4 of the issue).

### Verification

- `go build`, `go vet`, `helm lint` and `helm template` pass; both probes render with `tcpSocket` on the named port.
- Ran the binary: `/healthz` returns 404, `/metrics` returns 200, and a raw TCP connect to `:8000` (what the kubelet probe does) is accepted.

### Checklist

- [ ] Update issue checkboxes for points 1 and 2 after merge.