### PR TITLE
feat: drain connections and shut down cleanly on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Graceful shutdown: on SIGTERM, stop accepting, drain in-flight connections, then stop the metrics server.
+
 ### Changed
 
 - Probe the SOCKS5 port via `tcpSocket` for readiness and add a liveness probe.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -28,35 +32,59 @@ examples and usage of using your application. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		go func() {
+			<-ctx.Done()
+			// Restore default signal handling so a second signal
+			// terminates immediately instead of waiting for the drain.
+			stop()
+		}()
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
 		http.Handle("/metrics", promhttp.Handler())
 
+		metricsServer := &http.Server{
+			Addr:         ":8090",
+			Handler:      nil,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
+			IdleTimeout:  15 * time.Second,
+		}
+		metricsErr := make(chan error, 1)
 		go func() {
 			log.Println("Starting HTTP server on :8090")
-			server := &http.Server{
-				Addr:         ":8090",
-				Handler:      nil,
-				ReadTimeout:  5 * time.Second,
-				WriteTimeout: 10 * time.Second,
-				IdleTimeout:  15 * time.Second,
+			if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				metricsErr <- fmt.Errorf("metrics server: %w", err)
 			}
-			err := server.ListenAndServe()
-			if errors.Is(err, http.ErrServerClosed) {
-				fmt.Printf("server closed\n")
-			} else if err != nil {
-				fmt.Printf("error starting server: %s\n", err)
-				os.Exit(1)
-			}
+			cancel()
 		}()
 
-		log.Println("Starting SOCKS5 proxy server on :8000")
-		server := server.New()
-		if err := server.ListenAndServe("tcp", ":8000"); err != nil {
-			panic(err)
+		ln, err := net.Listen("tcp", ":8000")
+		if err != nil {
+			return fmt.Errorf("listening on :8000: %w", err)
 		}
+
+		log.Println("Starting SOCKS5 proxy server on :8000")
+		serveErr := server.Serve(ctx, server.New(), ln)
+
+		// Keep /metrics scrapeable during the drain; shut it down last.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
+			log.Printf("metrics server shutdown: %s", err)
+		}
+
+		select {
+		case err := <-metricsErr:
+			return err
+		default:
+		}
+		return serveErr
 	},
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -62,6 +64,35 @@ func New() *socks5.Server {
 	// Setup server
 	server := socks5.NewServer(opts...)
 	return server
+}
+
+// Serve accepts connections on ln and serves them with srv until ctx is
+// canceled, then stops accepting and waits for in-flight connections to
+// finish before returning.
+func Serve(ctx context.Context, srv *socks5.Server, ln net.Listener) error {
+	defer context.AfterFunc(ctx, func() { _ = ln.Close() })()
+
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			return err
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := srv.ServeConn(conn); err != nil {
+				log.Printf("socks5: connection error: %s", err)
+			}
+		}()
+	}
+
+	log.Println("socks5: draining in-flight connections")
+	wg.Wait()
+	return nil
 }
 
 // authenticatorFromConfig builds the authenticator from an htpasswd file, or

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,9 +1,14 @@
 package server
 
 import (
+	"context"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/things-go/go-socks5"
 	"golang.org/x/crypto/bcrypt"
@@ -28,6 +33,177 @@ func writeConfig(t *testing.T, content string) string {
 		t.Fatalf("write config: %s", err)
 	}
 	return path
+}
+
+// echoListener starts a TCP server that echoes everything back, for use as a
+// SOCKS5 CONNECT target.
+func echoListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen echo: %s", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				_, _ = io.Copy(conn, conn)
+				_ = conn.Close()
+			}()
+		}
+	}()
+	return ln
+}
+
+// socksConnect dials the proxy and performs a no-auth SOCKS5 handshake plus a
+// CONNECT to target, returning the tunneled connection.
+func socksConnect(t *testing.T, proxy, target string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", proxy)
+	if err != nil {
+		t.Fatalf("dial proxy: %s", err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Greeting: version 5, one method, no-auth.
+	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatalf("write greeting: %s", err)
+	}
+	reply := make([]byte, 2)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatalf("read method selection: %s", err)
+	}
+	if reply[0] != 0x05 || reply[1] != 0x00 {
+		t.Fatalf("unexpected method selection: %v", reply)
+	}
+
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		t.Fatalf("split target: %s", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("target port: %s", err)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x01} // CONNECT, IPv4
+	req = append(req, net.ParseIP(host).To4()...)
+	req = append(req, byte(port>>8), byte(port))
+	if _, err := conn.Write(req); err != nil {
+		t.Fatalf("write connect request: %s", err)
+	}
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(conn, head); err != nil {
+		t.Fatalf("read connect reply: %s", err)
+	}
+	if head[1] != 0x00 {
+		t.Fatalf("connect failed, reply code %d", head[1])
+	}
+	// Consume the bound address: 4 (IPv4) or 16 (IPv6) bytes plus 2 port bytes.
+	addrLen := 4
+	if head[3] == 0x04 {
+		addrLen = 16
+	}
+	if _, err := io.ReadFull(conn, make([]byte, addrLen+2)); err != nil {
+		t.Fatalf("read bound address: %s", err)
+	}
+	_ = conn.SetDeadline(time.Time{})
+	return conn
+}
+
+// echoRoundTrip sends msg through the tunnel and expects it echoed back.
+func echoRoundTrip(t *testing.T, conn net.Conn, msg string) {
+	t.Helper()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write([]byte(msg)); err != nil {
+		t.Fatalf("write through tunnel: %s", err)
+	}
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read through tunnel: %s", err)
+	}
+	if string(buf) != msg {
+		t.Fatalf("expected %q echoed back, got %q", msg, buf)
+	}
+	_ = conn.SetDeadline(time.Time{})
+}
+
+func TestServe(t *testing.T) {
+	t.Run("drains in-flight connections", func(t *testing.T) {
+		echo := echoListener(t)
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen proxy: %s", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- Serve(ctx, socks5.NewServer(), ln) }()
+
+		client := socksConnect(t, ln.Addr().String(), echo.Addr().String())
+		defer client.Close() // nolint: errcheck
+		echoRoundTrip(t, client, "hello")
+
+		cancel()
+
+		// New connections must be refused once the listener is closed.
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			conn, err := net.Dial("tcp", ln.Addr().String())
+			if err != nil {
+				break
+			}
+			_ = conn.Close()
+			if time.Now().After(deadline) {
+				t.Fatalf("listener still accepting after cancel")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// The in-flight tunnel keeps working while draining.
+		echoRoundTrip(t, client, "still alive")
+
+		select {
+		case err := <-done:
+			t.Fatalf("Serve returned before the connection finished: %v", err)
+		default:
+		}
+
+		_ = client.Close()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Serve returned error: %s", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Serve did not return after draining")
+		}
+	})
+
+	t.Run("returns promptly when idle", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen proxy: %s", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- Serve(ctx, socks5.NewServer(), ln) }()
+		cancel()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Serve returned error: %s", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Serve did not return after cancel")
+		}
+	})
 }
 
 func TestAuthenticatorFromConfig(t *testing.T) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37110

There was no SIGTERM handling: on pod termination all proxied connections were cut mid-flight and the metrics HTTP server was never drained.

### Changes

- New `server.Serve(ctx, srv, ln)` owns the accept loop (go-socks5 has no shutdown support) and tracks connections: on context cancellation it stops accepting and waits for in-flight connections to finish.
- `cmd/root.go` wires SIGTERM/SIGINT via `signal.NotifyContext`: close the listener, drain, keep `/metrics` scrapeable during the drain, then shut down the metrics server with a 5s timeout. A second signal terminates immediately; kubelet's SIGKILL after `terminationGracePeriodSeconds` is the drain deadline, so no in-process drain timeout.
- Switch cobra to `RunE`: startup failures now return errors instead of `panic(err)` or `os.Exit(1)` in a goroutine. This also covers the corresponding checkbox in the Logging section of the issue.
- Tests for `Serve`: a full SOCKS5 handshake through the proxy verifying that an in-flight tunnel keeps relaying while new connections are refused, and that `Serve` returns once the connection closes.

### Verification

- `go build`, `go vet`, `go test ./...` pass.
- End-to-end in an isolated netns: SIGTERM while a tunnel was active; the tunnel kept echoing for its full lifetime, `/metrics` returned 200 during the drain, new SOCKS connections were refused, and the process exited 0 after the drain. A second SIGTERM terminated immediately (exit 143).