### PR TITLE
refactor: standardize logging on log/slog with a JSON handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Probe the SOCKS5 port via `tcpSocket` for readiness and add a liveness probe.
+- Log in JSON via `log/slog`.
+- Fail startup with an error instead of `log.Fatalf` when authentication cannot be configured.
 
 ### Removed
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -32,8 +32,14 @@ examples and usage of using your application. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	SilenceUsage: true,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		srv, err := server.New()
+		if err != nil {
+			return err
+		}
+
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		go func() {
@@ -57,7 +63,7 @@ to quickly create a Cobra application.`,
 		}
 		metricsErr := make(chan error, 1)
 		go func() {
-			log.Println("Starting HTTP server on :8090")
+			slog.Info("starting metrics server", "addr", ":8090")
 			if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				metricsErr <- fmt.Errorf("metrics server: %w", err)
 			}
@@ -69,14 +75,14 @@ to quickly create a Cobra application.`,
 			return fmt.Errorf("listening on :8000: %w", err)
 		}
 
-		log.Println("Starting SOCKS5 proxy server on :8000")
-		serveErr := server.Serve(ctx, server.New(), ln)
+		slog.Info("starting SOCKS5 proxy server", "addr", ":8000")
+		serveErr := server.Serve(ctx, srv, ln)
 
 		// Keep /metrics scrapeable during the drain; shut it down last.
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-			log.Printf("metrics server shutdown: %s", err)
+			slog.Error("metrics server shutdown", "error", err)
 		}
 
 		select {
@@ -91,8 +97,11 @@ to quickly create a Cobra application.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+
 	err := rootCmd.Execute()
 	if err != nil {
+		slog.Error("command failed", "error", err)
 		os.Exit(1)
 	}
 }
@@ -131,6 +140,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		slog.Info("using config file", "path", viper.ConfigFileUsed())
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -43,27 +43,31 @@ func (c bcryptCredentials) Valid(user, password, _ string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
 }
 
+// slogAdapter implements socks5.Logger on top of slog.
+type slogAdapter struct {
+	logger *slog.Logger
+}
+
+// Errorf implements socks5.Logger.
+func (a slogAdapter) Errorf(format string, args ...interface{}) {
+	a.logger.Error(fmt.Sprintf(format, args...))
+}
+
 // New builds the SOCKS5 server with an authenticator derived from the
 // available configuration.
-func New() *socks5.Server {
-	logger := log.New(os.Stdout, "socks5: ", log.LstdFlags)
-
-	// Setup server options
+func New() (*socks5.Server, error) {
 	opts := []socks5.Option{
-		socks5.WithLogger(socks5.NewLogger(logger)),
+		socks5.WithLogger(slogAdapter{logger: slog.With("component", "socks5")}),
 		socks5.WithConnectMiddleware(UserConnect),
 	}
 
-	// Setup auth
 	authenticator, err := authenticatorFromConfig()
 	if err != nil {
-		log.Fatalf("failed to configure authentication: %s", err)
+		return nil, fmt.Errorf("configuring authentication: %w", err)
 	}
 	opts = append(opts, socks5.WithAuthMethods([]socks5.Authenticator{authenticator}))
 
-	// Setup server
-	server := socks5.NewServer(opts...)
-	return server
+	return socks5.NewServer(opts...), nil
 }
 
 // Serve accepts connections on ln and serves them with srv until ctx is
@@ -85,12 +89,12 @@ func Serve(ctx context.Context, srv *socks5.Server, ln net.Listener) error {
 		go func() {
 			defer wg.Done()
 			if err := srv.ServeConn(conn); err != nil {
-				log.Printf("socks5: connection error: %s", err)
+				slog.Error("connection error", "component", "socks5", "error", err)
 			}
 		}()
 	}
 
-	log.Println("socks5: draining in-flight connections")
+	slog.Info("draining in-flight connections", "component", "socks5")
 	wg.Wait()
 	return nil
 }
@@ -104,11 +108,11 @@ func authenticatorFromConfig() (socks5.Authenticator, error) {
 	}
 
 	if creds == nil {
-		log.Println("No authentication required")
+		slog.Info("no authentication required")
 		return socks5.NoAuthAuthenticator{}, nil
 	}
 
-	log.Printf("Authentication enabled for %d user(s)", len(creds))
+	slog.Info("authentication enabled", "users", len(creds))
 	return socks5.UserPassAuthenticator{Credentials: creds}, nil
 }
 
@@ -187,6 +191,6 @@ func UserConnect(ctx context.Context, writer io.Writer, request *socks5.Request)
 		}
 	}
 	userConnectMetric.WithLabelValues(user).Inc()
-	log.Printf("socks5: new connection from/to: %s %s (user: %s)", request.RemoteAddr, request.DestAddr, user)
+	slog.Info("new connection", "component", "socks5", "remote", request.RemoteAddr.String(), "destination", request.DestAddr.String(), "user", user)
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,12 @@ func (c bcryptCredentials) Valid(user, password, _ string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
 }
 
+// socksLog returns a logger tagged with the socks5 component. It resolves the
+// default logger lazily so it picks up the handler configured in Execute.
+func socksLog() *slog.Logger {
+	return slog.With("component", "socks5")
+}
+
 // slogAdapter implements socks5.Logger on top of slog.
 type slogAdapter struct {
 	logger *slog.Logger
@@ -57,7 +63,7 @@ func (a slogAdapter) Errorf(format string, args ...interface{}) {
 // available configuration.
 func New() (*socks5.Server, error) {
 	opts := []socks5.Option{
-		socks5.WithLogger(slogAdapter{logger: slog.With("component", "socks5")}),
+		socks5.WithLogger(slogAdapter{logger: socksLog()}),
 		socks5.WithConnectMiddleware(UserConnect),
 	}
 
@@ -89,12 +95,12 @@ func Serve(ctx context.Context, srv *socks5.Server, ln net.Listener) error {
 		go func() {
 			defer wg.Done()
 			if err := srv.ServeConn(conn); err != nil {
-				slog.Error("connection error", "component", "socks5", "error", err)
+				socksLog().Error("connection error", "error", err)
 			}
 		}()
 	}
 
-	slog.Info("draining in-flight connections", "component", "socks5")
+	socksLog().Info("draining in-flight connections")
 	wg.Wait()
 	return nil
 }
@@ -191,6 +197,6 @@ func UserConnect(ctx context.Context, writer io.Writer, request *socks5.Request)
 		}
 	}
 	userConnectMetric.WithLabelValues(user).Inc()
-	slog.Info("new connection", "component", "socks5", "remote", request.RemoteAddr.String(), "destination", request.DestAddr.String(), "user", user)
+	socksLog().Info("new connection", "remote", request.RemoteAddr.String(), "destination", request.DestAddr.String(), "user", user)
 	return nil
 }


### PR DESCRIPTION
Standardize all logging on `log/slog` with a JSON handler writing to stderr.

- Replace `log.Println`/`log.Printf`/`fmt.Fprintln` with structured `slog` calls.
- `server.New` now returns an error instead of calling `log.Fatalf`; the error propagates through cobra `RunE` and is logged as JSON in `Execute` before exiting with code 1 (`SilenceErrors` enabled so cobra does not also print it as plain text).
- Adapt the go-socks5 library logger to `slog` via a small `Errorf` adapter, tagged with `component=socks5`.

The `version` subcommand keeps `fmt.Println` since that is command output, not logging.

Towards https://github.com/giantswarm/giantswarm/issues/37110