### PR TITLE
feat: add auth/connection metrics and a ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Metrics: `proxysocks_auth_failures_total`, `proxysocks_active_connections`, and `proxysocks_connection_errors_total`.
+- Chart: a ServiceMonitor and a ClusterIP metrics Service to scrape `/metrics` (toggle via `metrics.serviceMonitor.enabled`).
 - Graceful shutdown: on SIGTERM, stop accepting, drain in-flight connections, then stop the metrics server.
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/helm/proxysocks/templates/_helpers.tpl
+++ b/helm/proxysocks/templates/_helpers.tpl
@@ -21,7 +21,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/name: {{ .Values.name | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 giantswarm.io/service-type: "{{ .Values.serviceType }}"
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}

--- a/helm/proxysocks/templates/deployment.yaml
+++ b/helm/proxysocks/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics
-              containerPort: 8090
+              containerPort: {{ .Values.metrics.port }}
             - name: socks5
               containerPort: {{ .Values.service.port }}
           readinessProbe:

--- a/helm/proxysocks/templates/metrics-service.yaml
+++ b/helm/proxysocks/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "labels.selector" . | nindent 4 }}
+{{- end }}

--- a/helm/proxysocks/templates/servicemonitor.yaml
+++ b/helm/proxysocks/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 60s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+{{- end }}

--- a/helm/proxysocks/values.schema.json
+++ b/helm/proxysocks/values.schema.json
@@ -58,6 +58,22 @@
                 }
             }
         },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer"
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "replicaCount": {
             "type": "integer"
         },

--- a/helm/proxysocks/values.yaml
+++ b/helm/proxysocks/values.yaml
@@ -24,6 +24,11 @@ service:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
 
+metrics:
+  port: 8090
+  serviceMonitor:
+    enabled: true
+
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,6 +28,21 @@ var (
 		Name: "proxysocks_user_connect_total",
 		Help: "The total number of user connections",
 	}, []string{"user"})
+
+	authFailureMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "proxysocks_auth_failures_total",
+		Help: "The total number of failed authentication attempts",
+	})
+
+	activeConnectionsMetric = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "proxysocks_active_connections",
+		Help: "The number of connections currently being served",
+	})
+
+	connectionErrorMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "proxysocks_connection_errors_total",
+		Help: "The total number of connections that ended with an error",
+	})
 )
 
 // bcryptCredentials maps usernames to bcrypt password hashes and implements
@@ -38,9 +53,14 @@ type bcryptCredentials map[string]string
 func (c bcryptCredentials) Valid(user, password, _ string) bool {
 	hash, ok := c[user]
 	if !ok {
+		authFailureMetric.Inc()
 		return false
 	}
-	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
+	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) != nil {
+		authFailureMetric.Inc()
+		return false
+	}
+	return true
 }
 
 // socksLog returns a logger tagged with the socks5 component. It resolves the
@@ -92,9 +112,12 @@ func Serve(ctx context.Context, srv *socks5.Server, ln net.Listener) error {
 			return err
 		}
 		wg.Add(1)
+		activeConnectionsMetric.Inc()
 		go func() {
 			defer wg.Done()
+			defer activeConnectionsMetric.Dec()
 			if err := srv.ServeConn(conn); err != nil {
+				connectionErrorMetric.Inc()
 				socksLog().Error("connection error", "error", err)
 			}
 		}()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/things-go/go-socks5"
+	"github.com/things-go/go-socks5/statute"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -23,6 +25,16 @@ func bcryptEntry(t *testing.T, username, password string) string {
 		t.Fatalf("generate hash: %s", err)
 	}
 	return username + ":" + string(hash)
+}
+
+// mustHash returns a bcrypt hash of password, failing the test on error.
+func mustHash(t *testing.T, password string) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("generate hash: %s", err)
+	}
+	return string(hash)
 }
 
 func writeConfig(t *testing.T, content string) string {
@@ -202,6 +214,73 @@ func TestServe(t *testing.T) {
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatalf("Serve did not return after cancel")
+		}
+	})
+}
+
+func TestValid(t *testing.T) {
+	creds := bcryptCredentials{"alice": mustHash(t, "s3cr3t")}
+
+	t.Run("correct credentials succeed without counting a failure", func(t *testing.T) {
+		before := testutil.ToFloat64(authFailureMetric)
+		if !creds.Valid("alice", "s3cr3t", "") {
+			t.Fatalf("expected valid credentials to pass")
+		}
+		if got := testutil.ToFloat64(authFailureMetric) - before; got != 0 {
+			t.Fatalf("expected no auth failures, got %v", got)
+		}
+	})
+
+	t.Run("wrong password counts a failure", func(t *testing.T) {
+		before := testutil.ToFloat64(authFailureMetric)
+		if creds.Valid("alice", "wrong", "") {
+			t.Fatalf("expected wrong password to fail")
+		}
+		if got := testutil.ToFloat64(authFailureMetric) - before; got != 1 {
+			t.Fatalf("expected one auth failure, got %v", got)
+		}
+	})
+
+	t.Run("unknown user counts a failure", func(t *testing.T) {
+		before := testutil.ToFloat64(authFailureMetric)
+		if creds.Valid("mallory", "whatever", "") {
+			t.Fatalf("expected unknown user to fail")
+		}
+		if got := testutil.ToFloat64(authFailureMetric) - before; got != 1 {
+			t.Fatalf("expected one auth failure, got %v", got)
+		}
+	})
+}
+
+func TestUserConnect(t *testing.T) {
+	req := func(user string) *socks5.Request {
+		r := &socks5.Request{
+			RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234},
+			DestAddr:   &statute.AddrSpec{IP: net.IPv4(10, 0, 0, 1), Port: 80},
+		}
+		if user != "" {
+			r.AuthContext = &socks5.AuthContext{Payload: map[string]string{"username": user}}
+		}
+		return r
+	}
+
+	t.Run("counts against the authenticated user", func(t *testing.T) {
+		before := testutil.ToFloat64(userConnectMetric.WithLabelValues("alice"))
+		if err := UserConnect(context.Background(), io.Discard, req("alice")); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got := testutil.ToFloat64(userConnectMetric.WithLabelValues("alice")) - before; got != 1 {
+			t.Fatalf("expected one connection for alice, got %v", got)
+		}
+	})
+
+	t.Run("falls back to anonymous without auth context", func(t *testing.T) {
+		before := testutil.ToFloat64(userConnectMetric.WithLabelValues("anonymous"))
+		if err := UserConnect(context.Background(), io.Discard, req("")); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got := testutil.ToFloat64(userConnectMetric.WithLabelValues("anonymous")) - before; got != 1 {
+			t.Fatalf("expected one anonymous connection, got %v", got)
 		}
 	})
 }


### PR DESCRIPTION
## What

Extends observability per the metrics section of the tracking issue.

### Metrics

Adds three metrics alongside the existing `proxysocks_user_connect_total`:

- `proxysocks_auth_failures_total` (counter) — incremented on unknown user or bad password.
- `proxysocks_active_connections` (gauge) — tracks connections currently being served.
- `proxysocks_connection_errors_total` (counter) — connections that ended with an error.

### Chart

- New ServiceMonitor plus a headless ClusterIP metrics Service so `/metrics` (port 8090) is scraped without exposing it on the socks5 LoadBalancer. Toggle via `metrics.serviceMonitor.enabled` (default `true`).
- Fix the `application.giantswarm.io/team` common label, which read a non-existent annotation key and rendered empty. It now resolves to `cabbage` from the chart annotation.

### Tests

- Cover `Valid` (auth-failure metric) and `UserConnect` (connect counter, anonymous fallback).

## Verification

`go build`, `go test`, `helm template`, and `helm lint` all pass.

Towards https://github.com/giantswarm/giantswarm/issues/37110