### PR TITLE
feat: harden auth and deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chart: a ServiceMonitor and a ClusterIP metrics Service to scrape `/metrics` (toggle via `metrics.serviceMonitor.enabled`).
 - Configurable listen addresses via `--socks-address` and `--metrics-address` flags.
 - Chart: an optional NetworkPolicy (`networkPolicy.enabled`) and a PodDisruptionBudget rendered when `replicaCount > 1`.
+- Chart: pod anti-affinity to spread replicas across nodes and `unhealthyPodEvictionPolicy: AlwaysAllow` on the PodDisruptionBudget.
 - Chart: a `checksum/htpasswd` pod annotation so pods roll when the managed htpasswd Secret changes.
 - Tests for `Valid` and `UserConnect` (authenticated and anonymous).
 - Graceful shutdown: on SIGTERM, stop accepting, drain in-flight connections, then stop the metrics server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metrics: `proxysocks_auth_failures_total`, `proxysocks_active_connections`, and `proxysocks_connection_errors_total`.
 - Chart: a ServiceMonitor and a ClusterIP metrics Service to scrape `/metrics` (toggle via `metrics.serviceMonitor.enabled`).
 - Configurable listen addresses via `--socks-address` and `--metrics-address` flags.
+- Chart: an optional NetworkPolicy (`networkPolicy.enabled`) and a PodDisruptionBudget rendered when `replicaCount > 1`.
+- Chart: a `checksum/htpasswd` pod annotation so pods roll when the managed htpasswd Secret changes.
+- Tests for `Valid` and `UserConnect` (authenticated and anonymous).
 - Graceful shutdown: on SIGTERM, stop accepting, drain in-flight connections, then stop the metrics server.
 
 ### Changed
 
+- Compare unknown users against a dummy bcrypt hash to prevent username enumeration by timing.
 - Probe the SOCKS5 port via `tcpSocket` for readiness and add a liveness probe.
 - Log in JSON via `log/slog`.
 - Fail startup with an error instead of `log.Fatalf` when authentication cannot be configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Run 2 replicas by default (`replicaCount: 2`) for high availability.
 - Compare unknown users against a dummy bcrypt hash to prevent username enumeration by timing.
 - Probe the SOCKS5 port via `tcpSocket` for readiness and add a liveness probe.
 - Log in JSON via `log/slog`.

--- a/helm/proxysocks/templates/deployment.yaml
+++ b/helm/proxysocks/templates/deployment.yaml
@@ -12,6 +12,12 @@ spec:
       {{- include "labels.selector" . | nindent 6 }}
   template:
     metadata:
+      {{- if and .Values.auth.enabled .Values.auth.createSecret }}
+      annotations:
+        # Roll pods when the managed htpasswd Secret changes. This does not
+        # cover auth.existingSecret, whose content the chart cannot see.
+        checksum/htpasswd: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         {{- include "labels.common" . | nindent 8 }}
     spec:

--- a/helm/proxysocks/templates/deployment.yaml
+++ b/helm/proxysocks/templates/deployment.yaml
@@ -21,6 +21,15 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "labels.selector" . | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/proxysocks/templates/networkpolicy.yaml
+++ b/helm/proxysocks/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: socks5
+          protocol: TCP
+        - port: metrics
+          protocol: TCP
+  # A SOCKS5 proxy must reach arbitrary destinations, so egress is unrestricted.
+  egress:
+    - {}
+{{- end }}

--- a/helm/proxysocks/templates/poddisruptionbudget.yaml
+++ b/helm/proxysocks/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+{{- end }}

--- a/helm/proxysocks/templates/poddisruptionbudget.yaml
+++ b/helm/proxysocks/templates/poddisruptionbudget.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}

--- a/helm/proxysocks/values.schema.json
+++ b/helm/proxysocks/values.schema.json
@@ -74,6 +74,25 @@
                 }
             }
         },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "minAvailable": {
+                    "type": "integer"
+                }
+            }
+        },
         "replicaCount": {
             "type": "integer"
         },

--- a/helm/proxysocks/values.yaml
+++ b/helm/proxysocks/values.yaml
@@ -1,5 +1,5 @@
 serviceType: "managed"
-replicaCount: 1
+replicaCount: 2
 
 image:
   registry: gsoci.azurecr.io

--- a/helm/proxysocks/values.yaml
+++ b/helm/proxysocks/values.yaml
@@ -29,6 +29,14 @@ metrics:
   serviceMonitor:
     enabled: true
 
+networkPolicy:
+  enabled: true
+
+podDisruptionBudget:
+  # Rendered only when replicaCount > 1.
+  enabled: true
+  minAvailable: 1
+
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,14 +49,21 @@ var (
 // socks5.CredentialStore.
 type bcryptCredentials map[string]string
 
+// dummyHash is a valid bcrypt hash (cost 10, matching `htpasswd -B`) used to
+// equalize the timing of authentication for unknown users, so response time
+// does not reveal whether a username exists.
+const dummyHash = "$2a$10$anpA9jrSarctHL86tcM7.OM/w.gGzLjLSXBiIEqWtWM1xQlU1syZy"
+
 // Valid implements socks5.CredentialStore.
 func (c bcryptCredentials) Valid(user, password, _ string) bool {
 	hash, ok := c[user]
 	if !ok {
-		authFailureMetric.Inc()
-		return false
+		// Compare against a dummy hash so an unknown username costs the
+		// same as a known one and cannot be distinguished by timing.
+		hash = dummyHash
 	}
-	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) != nil {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	if !ok || err != nil {
 		authFailureMetric.Inc()
 		return false
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -250,6 +250,14 @@ func TestValid(t *testing.T) {
 			t.Fatalf("expected one auth failure, got %v", got)
 		}
 	})
+
+	t.Run("unknown user with correct dummy-hash password fails", func(t *testing.T) {
+		// The dummy hash is compared for unknown users to equalize timing;
+		// it must never authenticate anyone, even with its own plaintext.
+		if creds.Valid("mallory", "proxysocks-dummy", "") {
+			t.Fatalf("expected unknown user to fail regardless of password")
+		}
+	})
 }
 
 func TestUserConnect(t *testing.T) {


### PR DESCRIPTION
## What

Hardens authentication and the Helm chart, and runs the deployment with 2 replicas by default.

### Auth
- Compare unknown users against a dummy bcrypt hash to prevent username enumeration by timing.
- Fail startup with an error instead of `log.Fatalf` when authentication cannot be configured.
- Add tests for `Valid` and `UserConnect` (authenticated and anonymous).

### Chart / deployment
- Run 2 replicas by default (`replicaCount: 2`) for high availability.
- Add an optional NetworkPolicy (`networkPolicy.enabled`) and a PodDisruptionBudget rendered when `replicaCount > 1`.
- Add a `checksum/htpasswd` pod annotation so pods roll when the managed htpasswd Secret changes.

## Testing
- `go build ./...` and `go test ./internal/...` pass.
- `helm lint` and `helm template` render cleanly (Deployment `replicas: 2`, PDB `minAvailable: 1`).

Towards https://github.com/giantswarm/giantswarm/issues/37110
