### PR TITLE
fix: log pre-handshake EOF at debug, not error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Log pre-handshake EOF (e.g. from `tcpSocket` probes) at debug instead of error, and stop counting it as a connection error.
+
 ## [0.4.0] - 2026-07-08
 
 ### Added

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -124,6 +125,14 @@ func Serve(ctx context.Context, srv *socks5.Server, ln net.Listener) error {
 			defer wg.Done()
 			defer activeConnectionsMetric.Dec()
 			if err := srv.ServeConn(conn); err != nil {
+				// A client that opens a connection and closes it before
+				// completing the SOCKS5 handshake (e.g. a TCP health check or
+				// port probe) surfaces as EOF. That is benign, so log it at
+				// debug and do not count it as a connection error.
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					socksLog().Debug("client disconnected before handshake", "error", err)
+					return
+				}
 				connectionErrorMetric.Inc()
 				socksLog().Error("connection error", "error", err)
 			}


### PR DESCRIPTION
## What

A client that opens a TCP connection and closes it before completing the SOCKS5 handshake surfaces from `srv.ServeConn` as a bare `io.EOF`. The main source is our own `tcpSocket` readiness/liveness probes (also port scanners and LB checks), which produce one such event per probe.

Previously this was logged at `ERROR` and incremented `proxysocks_connection_errors_total`, creating constant noise and inflating the error metric.

## Change

- Treat pre-handshake `io.EOF` / `io.ErrUnexpectedEOF` as a benign disconnect: log at debug and do not count it as a connection error.
- Real errors still log at error and increment the metric.

## Testing

- `go build ./...`, `go vet`, and `go test ./internal/server/` pass.